### PR TITLE
Added support for sheets with data-item-id in a parent other than .item

### DIFF
--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -159,7 +159,9 @@ export class helper{
 
       for(let img of itemImages){
         img = $(img);
-        let li = img.parents(".item");
+        
+        let itemTag = game.system.hasOwnProperty('itemTag') ? game.system.itemTag() : '.item'
+        let li = img.parents(itemTag);
         let id = li.attr("data-item-id") ?? img.attr("data-item-id");
         if (!id) {
           logger.debug("Id Error | ", img, li, id);

--- a/scripts/systems/demonlord.js
+++ b/scripts/systems/demonlord.js
@@ -72,6 +72,10 @@ export function register_helper()
 			return item.executeMacro();
 		return actor.rollSpell(item.id);
 	}
+
+	game.system.itemTag = () => {
+		return '.dl-item-row'
+	}
 }
 
 export function sheetHooks()


### PR DESCRIPTION
Adds support for putting "data-item-id" from a parent other than .item, and implements it in the demonlord system to fix executing item macros from the character sheet.