### PR TITLE
Fixed: Tidy 5e Hook Errors in Item Macro

### DIFF
--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -109,7 +109,6 @@ export class helper{
     switch(game.system.id) {
       case "dnd5e" :
         if (settings.value("defaultmacro")) dnd5e.register_helper();
-        dnd5e.applyTidy5eCompatibility();
         break;
       case "sfrpg" :
         if(settings.value("defaultmacro")) sfrpg.register_helper();

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -46,37 +46,3 @@ export function sheetHooks() {
 
   return {render: renderSheets, rendered: renderedSheets};
 }
-
-/**
- * Provides module compatibility with the new Tidy 5e Sheets: https://github.com/kgar/foundry-vtt-tidy-5e-sheets/
- */
-export function applyTidy5eCompatibility() {
-  /**
-   * When the user clicks the use item button, allow Item Macro to override, based on settings.
-   */
-  Hooks.on("tidy5e-sheet.actorPreUseItem", (item, config, options) => {
-    const shouldExecuteMacro =
-      settings.value("charsheet") &&
-      !settings.value("click") &&
-      item.hasMacro();
-    if (shouldExecuteMacro) {
-      item.executeMacro({config, options});
-      return false;
-    }
-  });
-
-  /**
-   * When the user right-clicks the use item button, allow Item Macro to hook in and add behaviors, based on settings.
-   */
-  Hooks.on("tidy5e-sheet.actorItemUseContextMenu", (item, options) => {
-    const shouldExecuteMacro =
-      settings.value("charsheet") &&
-      settings.value("click") &&
-      item.hasMacro();
-    if (shouldExecuteMacro) {
-      item.executeMacro({options});
-      options.event.preventDefault();
-      options.event.stopPropagation();
-    }
-  });
-}


### PR DESCRIPTION
I removed the Tidy 5e Sheets integration, because the preUseItem approach is working perfectly for Tidy with no more need for special integration.

Now that the settings have been removed for dnd5e, Tidy is currently getting this error when attempting to run integration code:

![image](https://github.com/Foundry-Workshop/Item-Macro/assets/4632129/e7dde464-1dcf-4416-abac-8cafd7289864)

![image](https://github.com/Foundry-Workshop/Item-Macro/assets/4632129/08481f82-3cc6-4b9b-87c0-eecf73b0869b)
